### PR TITLE
docs: fix docker compose instructions and update versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@ Docker image for [JelmerT/cc2538-bsl](https://github.com/JelmerT/cc2538-bsl)
 ### Docker
 #### Example: download firmware and flash to SONOFF Dongle Plus
 ```sh
-$ docker run --rm --device /dev/ttyUSB0:/dev/ttyUSB0 -e FIRMWARE_URL=https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_launchpad_coordinator_20211217.zip ckware/ti-cc-tool -ewv -p /dev/ttyUSB0 --bootloader-sonoff-usb
+$ docker run --rm --device /dev/ttyUSB0:/dev/ttyUSB0 -e FIRMWARE_URL=https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_launchpad_coordinator_20220219.zip ckware/ti-cc-tool -ewv -p /dev/ttyUSB0 --bootloader-sonoff-usb
 ```
 
 #### Example: flash local firmware file to SONOFF Dongle Plus
-* This example expects the file `CC1352P2_CC2652P_launchpad_coordinator_20211217.zip` in the local directory
+* This example expects the file `CC1352P2_CC2652P_launchpad_coordinator_20220219.zip` in the local directory
 * ```sh
-  $ docker run --rm --device /dev/ttyUSB0:/dev/ttyUSB0 -e FIRMWARE_FILE=CC1352P2_CC2652P_launchpad_coordinator_20211217.zip ckware/ti-cc-tool -ewv -p /dev/ttyUSB0 --bootloader-sonoff-usb
+  $ docker run --rm --device /dev/ttyUSB0:/dev/ttyUSB0 -e FIRMWARE_FILE=CC1352P2_CC2652P_launchpad_coordinator_20220219.zip ckware/ti-cc-tool -ewv -p /dev/ttyUSB0 --bootloader-sonoff-usb
   ```
 
 ### docker-compose
 1. Create a `docker-compose.yml` for your environment
-1. Run `docker-compose run --rm ckware/ti-cc-tool`
+1. Run `docker-compose run --rm ti-cc-tool`
 
 #### Example: download firmware and flash to SONOFF Dongle Plus
 ```yaml
@@ -28,9 +28,9 @@ services:
   ti-cc-tool:
     image: "ckware/ti-cc-tool"
     environment:
-      FIRMWARE_URL: "https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_launchpad_coordinator_20211217.zip"
+      FIRMWARE_URL: "https://github.com/Koenkk/Z-Stack-firmware/raw/master/coordinator/Z-Stack_3.x.0/bin/CC1352P2_CC2652P_launchpad_coordinator_20220219.zip"
     devices:
-      "/dev/ttyUSB0:/dev/ttyUSB0"
+      - "/dev/ttyUSB0:/dev/ttyUSB0"
     command: [ "-ewv", "-p", "/dev/ttyUSB0", "--bootloader-sonoff-usb" ]
 ```
 
@@ -41,11 +41,11 @@ services:
   ti-cc-tool:
     image: "ckware/ti-cc-tool"
     devices:
-      "/dev/ttyUSB0:/dev/ttyUSB0"
+      - "/dev/ttyUSB0:/dev/ttyUSB0"
     environment:
       FIRMWARE_FILE: "/firmware.zip"
     volumes:
-      - "./CC1352P2_CC2652P_launchpad_coordinator_20211217.zip:/firmware.zip"
+      - "./CC1352P2_CC2652P_launchpad_coordinator_20220219.zip:/firmware.zip"
     command: [ "-ewv", "-p", "/dev/ttyUSB0", "--bootloader-sonoff-usb" ]
 
 ```


### PR DESCRIPTION
docker compose has to reference the service name, not image name. Devices are listed in an array, not map.